### PR TITLE
correct create_personality function params to reflect usage

### DIFF
--- a/docs/source/plug-in.md
+++ b/docs/source/plug-in.md
@@ -33,7 +33,7 @@ class TemplatePersonality(LoggingConfigurable):
 
 def create_personality(parent, log):
     """Put docstring here."""
-    return TemplatePersonality(parent=parent)
+    return TemplatePersonality(parent=parent, log=log)
 ```
 
 Provided personalities include [kernel_gateway.jupyter_websocket](websocket-mode.md) and [kernel_gateway.notebook_http](http-mode.md).

--- a/docs/source/plug-in.md
+++ b/docs/source/plug-in.md
@@ -31,7 +31,7 @@ class TemplatePersonality(LoggingConfigurable):
         been specified."""
         pass
 
-def create_personality(self, parent):
+def create_personality(parent, log):
     """Put docstring here."""
     return TemplatePersonality(parent=parent)
 ```

--- a/docs/source/plug-in.md
+++ b/docs/source/plug-in.md
@@ -31,9 +31,9 @@ class TemplatePersonality(LoggingConfigurable):
         been specified."""
         pass
 
-def create_personality(parent, log):
+def create_personality(*args, **kwargs):
     """Put docstring here."""
-    return TemplatePersonality(parent=parent, log=log)
+    return TemplatePersonality(*args, **kwargs)
 ```
 
 Provided personalities include [kernel_gateway.jupyter_websocket](websocket-mode.md) and [kernel_gateway.notebook_http](http-mode.md).


### PR DESCRIPTION
The names of the positions args used in the docs don't reflect [usage](https://github.com/jupyter-server/kernel_gateway/blob/c72803ab1ea4bb75847917e0a7c682acbe700fbe/kernel_gateway/gatewayapp.py#L447); this leads to a `TypeError`. This change address that issue.

```
  File ".../gateway#link-tree/kernel_gateway/gatewayapp.py", line 447, in init_configurables
    self.personality = func(parent=self, log=self.log)
TypeError: create_personality() got an unexpected keyword argument 'log'
````