### PR TITLE
Support bash kernel in notebook-http mode

### DIFF
--- a/kernel_gateway/notebook_http/request_utils.py
+++ b/kernel_gateway/notebook_http/request_utils.py
@@ -25,6 +25,8 @@ def format_request(bundle, kernel_language=''):
     bundle = json.dumps(bundle)
     if kernel_language.lower() == 'perl':
         statement = "my $REQUEST = {}".format(bundle)
+    elif kernel_language.lower() == 'bash':
+        statement = "REQUEST={}".format(bundle)
     else:
         statement = "REQUEST = {}".format(bundle)
     return statement


### PR DESCRIPTION
While looking into #381, it was found that the execution request sent to the kernel to initialize the `REQUEST` information into the kernel's state, was triggering a `command not found` exception because `bash` variable initialization doesn't tolerate space-separated initialization and, as a result, took the following statement as an attempt to execute the command `REQUEST`:
```
REQUEST = "{\\"body\\": \\"\\", \\"args\\": {}, \\"path\\": {}, \\"headers\\": {\\"Host\\": \\"127.0.0.1:10100\\", \\"User-Agent\\": \\"curl/7.85.0\\", \\"Accept\\": \\"*/*\\"}}"
```
This pull request adds an additional format statement unique to `bash` kernels that removes the spaces around the statement, resulting in an execution request of:
```
REQUEST="{\\"body\\": \\"\\", \\"args\\": {}, \\"path\\": {}, \\"headers\\": {\\"Host\\": \\"127.0.0.1:10100\\", \\"User-Agent\\": \\"curl/7.85.0\\", \\"Accept\\": \\"*/*\\"}}"
```

Resolves #381